### PR TITLE
V2.1 - Extension Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (2025-06-17)
+
+### 🚀 Features
+
+- **eslint-config-airbnb-extended:** Added `extensions` feature for creating own config by yourself.
+
 ## 2.0.0 (2025-06-16)
 
 ### 🚀 Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-airbnb-extended-project",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Eslint Airbnb Config Extended Project",
   "bugs": {
     "url": "https://github.com/NishargShah/eslint-config-airbnb-extended/issues"

--- a/packages/create-airbnb-x-config/package.json
+++ b/packages/create-airbnb-x-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-airbnb-x-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Airbnb Extended Config CLI",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-airbnb-extended/configs/base/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/configs/base/recommended.ts
@@ -1,36 +1,11 @@
 import baseConfig from '@/configs/base/config';
-import getImportSettings from '@/helpers/getImportSettings';
-import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
-import { allFiles, jsFileWithoutReact } from '@/utils';
+import baseRecommendedExtensionsConfig from '@/extensions/base/recommended';
 
 import type { Linter } from 'eslint';
 
 const baseRecommendedConfig = [
   ...Object.values(baseConfig),
-  {
-    name: 'airbnb/config/base-configurations',
-    files: allFiles,
-    languageOptions: {
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'module',
-      },
-    },
-    settings: {
-      'import-x/core-modules': [],
-      'import-x/ignore': ['node_modules', String.raw`\.(coffee|scss|css|less|hbs|svg|json)$`],
-    },
-  },
-  {
-    name: 'airbnb/config/base-settings-extensions-configurations',
-    files: jsFileWithoutReact,
-    settings: getImportSettings({ javascript: true, typescript: false, jsx: false }),
-  },
-  {
-    name: 'airbnb/config/base-disable-legacy-stylistic-js-config',
-    files: allFiles,
-    ...getStylisticLegacyConfig('javascript'),
-  },
+  ...baseRecommendedExtensionsConfig,
 ] satisfies Linter.Config[];
 
 export default baseRecommendedConfig;

--- a/packages/eslint-config-airbnb-extended/configs/base/typescript.ts
+++ b/packages/eslint-config-airbnb-extended/configs/base/typescript.ts
@@ -1,29 +1,11 @@
-import { configs } from 'typescript-eslint';
-
 import typescriptConfig from '@/configs/typescript/config';
-import getImportSettings from '@/helpers/getImportSettings';
-import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
-import { jsFiles, tsFiles, tsFileWithoutReact } from '@/utils';
+import baseTypescriptExtensionsConfig from '@/extensions/base/typescript';
 
 import type { Linter } from 'eslint';
 
 const baseTypescriptConfig = [
   ...Object.values(typescriptConfig),
-  {
-    name: 'airbnb/config/base-typescript-settings-extensions-configurations',
-    files: tsFileWithoutReact,
-    settings: getImportSettings({ javascript: false, typescript: true, jsx: false }),
-  },
-  {
-    name: 'airbnb/config/base-typescript-disable-legacy-stylistic-ts-config',
-    files: tsFiles,
-    ...getStylisticLegacyConfig('typescript'),
-  },
-  {
-    ...configs.disableTypeChecked,
-    name: 'airbnb/config/base-typescript-disable-type-checked',
-    files: jsFiles,
-  },
+  ...baseTypescriptExtensionsConfig,
 ] as Linter.Config[];
 
 export default baseTypescriptConfig;

--- a/packages/eslint-config-airbnb-extended/configs/next/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/configs/next/recommended.ts
@@ -1,27 +1,13 @@
 import nextConfig from '@/configs/next/config';
 import reactRecommendedConfig from '@/configs/react/recommended';
-import { allFiles } from '@/utils';
+import nextRecommendedExtensionsConfig from '@/extensions/next/recommended';
 
 import type { Linter } from 'eslint';
 
 const nextRecommendedConfig = [
   ...reactRecommendedConfig,
   ...Object.values(nextConfig),
-  {
-    name: 'airbnb/config/next-import-x',
-    files: ['**/app/**/route.ts', '**/middleware.ts'],
-    rules: {
-      'import-x/prefer-default-export': 'off',
-    },
-  },
-  {
-    name: 'airbnb/config/next-react-jsx-runtime',
-    files: allFiles,
-    rules: {
-      'react/jsx-uses-react': 'off',
-      'react/react-in-jsx-scope': 'off',
-    },
-  },
+  ...nextRecommendedExtensionsConfig,
 ] satisfies Linter.Config[];
 
 export default nextRecommendedConfig;

--- a/packages/eslint-config-airbnb-extended/configs/node/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/configs/node/recommended.ts
@@ -1,59 +1,11 @@
-import nodePlugin from 'eslint-plugin-n';
-
 import nodeConfig from '@/configs/node/config';
-import nodeNoUnsupportedFeaturesRules from '@/rules/node/nodeNoUnsupportedFeatures';
-import { allFiles } from '@/utils';
+import nodeRecommendedExtensionsConfig from '@/extensions/node/recommended';
 
 import type { Linter } from 'eslint';
 
-const flatNodeConfig = nodePlugin.configs['flat/recommended'];
-const flatModuleConfig = nodePlugin.configs['flat/recommended-module'];
-const flatScriptConfig = nodePlugin.configs['flat/recommended-script'];
-
 const nodeRecommendedConfig = [
   ...Object.values(nodeConfig),
-  {
-    name: 'airbnb/config/node-configurations',
-    files: allFiles,
-    ...(flatNodeConfig
-      ? {
-          languageOptions: flatNodeConfig.languageOptions,
-          rules: {
-            'n/no-unsupported-features/es-syntax':
-              flatNodeConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
-              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
-          },
-        }
-      : null),
-  },
-  {
-    name: 'airbnb/config/node-configurations-for-module',
-    files: ['**/*.mjs', '**/*.mts'],
-    ...(flatModuleConfig
-      ? {
-          languageOptions: flatModuleConfig.languageOptions,
-          rules: {
-            'n/no-unsupported-features/es-syntax':
-              flatModuleConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
-              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
-          },
-        }
-      : null),
-  },
-  {
-    name: 'airbnb/config/node-configurations-for-script',
-    files: ['**/*.cjs', '**/*.cts'],
-    ...(flatScriptConfig
-      ? {
-          languageOptions: flatScriptConfig.languageOptions,
-          rules: {
-            'n/no-unsupported-features/es-syntax':
-              flatScriptConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
-              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
-          },
-        }
-      : null),
-  },
+  ...nodeRecommendedExtensionsConfig,
 ] satisfies Linter.Config[];
 
 export default nodeRecommendedConfig;

--- a/packages/eslint-config-airbnb-extended/configs/react/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/configs/react/recommended.ts
@@ -1,77 +1,11 @@
 import reactConfig from '@/configs/react/config';
-import getImportSettings from '@/helpers/getImportSettings';
-import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
-import styleRules from '@/rules/style';
-import { allFiles, jsFiles } from '@/utils';
+import reactRecommendedExtensionsConfig from '@/extensions/react/recommended';
 
 import type { Linter } from 'eslint';
 
-const dangleRules = styleRules.rules['no-underscore-dangle'];
-
 const reactRecommendedConfig = [
   ...Object.values(reactConfig),
-  {
-    name: 'airbnb/config/react-settings-extensions-configurations',
-    files: jsFiles,
-    settings: getImportSettings({ javascript: true, typescript: false, jsx: true }),
-  },
-  {
-    name: 'airbnb/config/react-configurations',
-    files: allFiles,
-    rules: {
-      // disallow dangling underscores in identifiers
-      // https://eslint.org/docs/latest/rules/no-underscore-dangle
-      // Allow Redux devtools variable
-      'no-underscore-dangle': [
-        dangleRules[0],
-        {
-          ...dangleRules[1],
-          allow: [...dangleRules[1].allow, '__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
-        },
-      ],
-
-      // enforce that class methods use "this"
-      // https://eslint.org/docs/rules/class-methods-use-this
-      // Class Methods can be used in React
-      'class-methods-use-this': [
-        'error',
-        {
-          exceptMethods: [
-            'render',
-            'getInitialState',
-            'getDefaultProps',
-            'getChildContext',
-            'componentWillMount',
-            'UNSAFE_componentWillMount',
-            'componentDidMount',
-            'componentWillReceiveProps',
-            'UNSAFE_componentWillReceiveProps',
-            'shouldComponentUpdate',
-            'componentWillUpdate',
-            'UNSAFE_componentWillUpdate',
-            'componentDidUpdate',
-            'componentWillUnmount',
-            'componentDidCatch',
-            'getSnapshotBeforeUpdate',
-          ],
-        },
-      ],
-    },
-  },
-  {
-    name: 'airbnb/config/react-stylistic',
-    files: allFiles,
-    rules: {
-      // specify whether double or single quotes should be used in JSX attributes
-      // https://eslint.style/rules/js/jsx-quotes
-      '@stylistic/jsx-quotes': ['error', 'prefer-double'],
-    },
-  },
-  {
-    name: 'airbnb/config/react-disable-legacy-stylistic-react-config',
-    files: allFiles,
-    ...getStylisticLegacyConfig('react'),
-  },
+  ...reactRecommendedExtensionsConfig,
 ] satisfies Linter.Config[];
 
 export default reactRecommendedConfig;

--- a/packages/eslint-config-airbnb-extended/extensions/base/index.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/base/index.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return, unicorn/prefer-module */
+
+import type { Linter } from 'eslint';
+
+/**
+ * as is given due to less size of index.d.ts
+ */
+const baseExtensions = {
+  get recommended(): Linter.Config[] {
+    return require('@/extensions/base/recommended').default;
+  },
+  get typescript(): Linter.Config[] {
+    return require('@/extensions/base/typescript').default;
+  },
+};
+
+export default baseExtensions;

--- a/packages/eslint-config-airbnb-extended/extensions/base/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/base/recommended.ts
@@ -1,0 +1,34 @@
+import getImportSettings from '@/helpers/getImportSettings';
+import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
+import { allFiles, jsFileWithoutReact } from '@/utils';
+
+import type { Linter } from 'eslint';
+
+const baseRecommendedExtensionsConfig = [
+  {
+    name: 'airbnb/config/base-configurations',
+    files: allFiles,
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      'import-x/core-modules': [],
+      'import-x/ignore': ['node_modules', String.raw`\.(coffee|scss|css|less|hbs|svg|json)$`],
+    },
+  },
+  {
+    name: 'airbnb/config/base-settings-extensions-configurations',
+    files: jsFileWithoutReact,
+    settings: getImportSettings({ javascript: true, typescript: false, jsx: false }),
+  },
+  {
+    name: 'airbnb/config/base-disable-legacy-stylistic-js-config',
+    files: allFiles,
+    ...getStylisticLegacyConfig('javascript'),
+  },
+] satisfies Linter.Config[];
+
+export default baseRecommendedExtensionsConfig;

--- a/packages/eslint-config-airbnb-extended/extensions/base/typescript.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/base/typescript.ts
@@ -1,0 +1,27 @@
+import { configs } from 'typescript-eslint';
+
+import getImportSettings from '@/helpers/getImportSettings';
+import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
+import { jsFiles, tsFiles, tsFileWithoutReact } from '@/utils';
+
+import type { Linter } from 'eslint';
+
+const baseTypescriptExtensionsConfig = [
+  {
+    name: 'airbnb/config/base-typescript-settings-extensions-configurations',
+    files: tsFileWithoutReact,
+    settings: getImportSettings({ javascript: false, typescript: true, jsx: false }),
+  },
+  {
+    name: 'airbnb/config/base-typescript-disable-legacy-stylistic-ts-config',
+    files: tsFiles,
+    ...getStylisticLegacyConfig('typescript'),
+  },
+  {
+    ...configs.disableTypeChecked,
+    name: 'airbnb/config/base-typescript-disable-type-checked',
+    files: jsFiles,
+  },
+] as Linter.Config[];
+
+export default baseTypescriptExtensionsConfig;

--- a/packages/eslint-config-airbnb-extended/extensions/index.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/index.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return, unicorn/prefer-module */
+
+import type { Linter } from 'eslint';
+
+import type baseExtensions from '@/extensions/base';
+import type nextExtensions from '@/extensions/next';
+import type nodeExtensions from '@/extensions/node';
+import type reactExtensions from '@/extensions/react';
+
+/**
+ * as is given due to less size of index.d.ts
+ */
+const extensions = {
+  get base(): Record<keyof typeof baseExtensions, Linter.Config[]> {
+    return require('@/extensions/base').default;
+  },
+  get react(): Record<keyof typeof reactExtensions, Linter.Config[]> {
+    return require('@/extensions/react').default;
+  },
+  get next(): Record<keyof typeof nextExtensions, Linter.Config[]> {
+    return require('@/extensions/next').default;
+  },
+  get node(): Record<keyof typeof nodeExtensions, Linter.Config[]> {
+    return require('@/extensions/node').default;
+  },
+};
+
+export default extensions;

--- a/packages/eslint-config-airbnb-extended/extensions/next/index.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/next/index.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return, unicorn/prefer-module */
+
+import type { Linter } from 'eslint';
+
+/**
+ * as is given due to less size of index.d.ts
+ */
+const nextExtensions = {
+  get recommended(): Linter.Config[] {
+    return require('@/extensions/next/recommended').default;
+  },
+};
+
+export default nextExtensions;

--- a/packages/eslint-config-airbnb-extended/extensions/next/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/next/recommended.ts
@@ -1,0 +1,23 @@
+import { allFiles } from '@/utils';
+
+import type { Linter } from 'eslint';
+
+const nextRecommendedExtensionsConfig = [
+  {
+    name: 'airbnb/config/next-import-x',
+    files: ['**/app/**/route.ts', '**/middleware.ts'],
+    rules: {
+      'import-x/prefer-default-export': 'off',
+    },
+  },
+  {
+    name: 'airbnb/config/next-react-jsx-runtime',
+    files: allFiles,
+    rules: {
+      'react/jsx-uses-react': 'off',
+      'react/react-in-jsx-scope': 'off',
+    },
+  },
+] satisfies Linter.Config[];
+
+export default nextRecommendedExtensionsConfig;

--- a/packages/eslint-config-airbnb-extended/extensions/node/index.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/node/index.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return, unicorn/prefer-module */
+
+import type { Linter } from 'eslint';
+
+/**
+ * as is given due to less size of index.d.ts
+ */
+const nodeExtensions = {
+  get recommended(): Linter.Config[] {
+    return require('@/extensions/node/recommended').default;
+  },
+};
+
+export default nodeExtensions;

--- a/packages/eslint-config-airbnb-extended/extensions/node/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/node/recommended.ts
@@ -1,0 +1,57 @@
+import nodePlugin from 'eslint-plugin-n';
+
+import nodeNoUnsupportedFeaturesRules from '@/rules/node/nodeNoUnsupportedFeatures';
+import { allFiles } from '@/utils';
+
+import type { Linter } from 'eslint';
+
+const flatNodeConfig = nodePlugin.configs['flat/recommended'];
+const flatModuleConfig = nodePlugin.configs['flat/recommended-module'];
+const flatScriptConfig = nodePlugin.configs['flat/recommended-script'];
+
+const nodeRecommendedExtensionsConfig = [
+  {
+    name: 'airbnb/config/node-configurations',
+    files: allFiles,
+    ...(flatNodeConfig
+      ? {
+          languageOptions: flatNodeConfig.languageOptions,
+          rules: {
+            'n/no-unsupported-features/es-syntax':
+              flatNodeConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
+              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
+          },
+        }
+      : null),
+  },
+  {
+    name: 'airbnb/config/node-configurations-for-module',
+    files: ['**/*.mjs', '**/*.mts'],
+    ...(flatModuleConfig
+      ? {
+          languageOptions: flatModuleConfig.languageOptions,
+          rules: {
+            'n/no-unsupported-features/es-syntax':
+              flatModuleConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
+              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
+          },
+        }
+      : null),
+  },
+  {
+    name: 'airbnb/config/node-configurations-for-script',
+    files: ['**/*.cjs', '**/*.cts'],
+    ...(flatScriptConfig
+      ? {
+          languageOptions: flatScriptConfig.languageOptions,
+          rules: {
+            'n/no-unsupported-features/es-syntax':
+              flatScriptConfig.rules?.['n/no-unsupported-features/es-syntax'] ??
+              nodeNoUnsupportedFeaturesRules.rules['n/no-unsupported-features/es-syntax'],
+          },
+        }
+      : null),
+  },
+] satisfies Linter.Config[];
+
+export default nodeRecommendedExtensionsConfig;

--- a/packages/eslint-config-airbnb-extended/extensions/react/index.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/react/index.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return, unicorn/prefer-module */
+
+import type { Linter } from 'eslint';
+
+/**
+ * as is given due to less size of index.d.ts
+ */
+const reactExtensions = {
+  get recommended(): Linter.Config[] {
+    return require('@/extensions/react/recommended').default;
+  },
+};
+
+export default reactExtensions;

--- a/packages/eslint-config-airbnb-extended/extensions/react/recommended.ts
+++ b/packages/eslint-config-airbnb-extended/extensions/react/recommended.ts
@@ -1,0 +1,75 @@
+import getImportSettings from '@/helpers/getImportSettings';
+import getStylisticLegacyConfig from '@/helpers/getStylisticLegacyConfig';
+import styleRules from '@/rules/style';
+import { allFiles, jsFiles } from '@/utils';
+
+import type { Linter } from 'eslint';
+
+const dangleRules = styleRules.rules['no-underscore-dangle'];
+
+const reactRecommendedExtensionsConfig = [
+  {
+    name: 'airbnb/config/react-settings-extensions-configurations',
+    files: jsFiles,
+    settings: getImportSettings({ javascript: true, typescript: false, jsx: true }),
+  },
+  {
+    name: 'airbnb/config/react-configurations',
+    files: allFiles,
+    rules: {
+      // disallow dangling underscores in identifiers
+      // https://eslint.org/docs/latest/rules/no-underscore-dangle
+      // Allow Redux devtools variable
+      'no-underscore-dangle': [
+        dangleRules[0],
+        {
+          ...dangleRules[1],
+          allow: [...dangleRules[1].allow, '__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
+        },
+      ],
+
+      // enforce that class methods use "this"
+      // https://eslint.org/docs/rules/class-methods-use-this
+      // Class Methods can be used in React
+      'class-methods-use-this': [
+        'error',
+        {
+          exceptMethods: [
+            'render',
+            'getInitialState',
+            'getDefaultProps',
+            'getChildContext',
+            'componentWillMount',
+            'UNSAFE_componentWillMount',
+            'componentDidMount',
+            'componentWillReceiveProps',
+            'UNSAFE_componentWillReceiveProps',
+            'shouldComponentUpdate',
+            'componentWillUpdate',
+            'UNSAFE_componentWillUpdate',
+            'componentDidUpdate',
+            'componentWillUnmount',
+            'componentDidCatch',
+            'getSnapshotBeforeUpdate',
+          ],
+        },
+      ],
+    },
+  },
+  {
+    name: 'airbnb/config/react-stylistic',
+    files: allFiles,
+    rules: {
+      // specify whether double or single quotes should be used in JSX attributes
+      // https://eslint.style/rules/js/jsx-quotes
+      '@stylistic/jsx-quotes': ['error', 'prefer-double'],
+    },
+  },
+  {
+    name: 'airbnb/config/react-disable-legacy-stylistic-react-config',
+    files: allFiles,
+    ...getStylisticLegacyConfig('react'),
+  },
+] satisfies Linter.Config[];
+
+export default reactRecommendedExtensionsConfig;

--- a/packages/eslint-config-airbnb-extended/index.ts
+++ b/packages/eslint-config-airbnb-extended/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import-x/no-rename-default, unicorn/prefer-export-from */
 
 import allConfigs from '@/configs';
+import allExtensions from '@/extensions';
 import allPlugins from '@/plugins';
 import allRules from '@/rules';
 
@@ -12,3 +13,5 @@ export const rules = allRules;
 export const configs = allConfigs;
 
 export const plugins = allPlugins;
+
+export const extensions = allExtensions;

--- a/packages/eslint-config-airbnb-extended/package.json
+++ b/packages/eslint-config-airbnb-extended/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-airbnb-extended",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Eslint Airbnb Config Extended",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Before

In the code, many places have defined config that can't be exposed because its in `recommended` config or `typescript` config so if you want to make your `own` base config then it is not possible.

After

Now you can use `extensions` to create the same own config with the full customization